### PR TITLE
GitHub Pages Deploy Script

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,17 +89,25 @@ module.exports = function(grunt) {
         ],
         tasks: ['newer:copy']
       }
-    }
+    },
 
+    'gh-pages': {
+        options: {
+          base: 'dist'
+        },
+        src: ['**']
+      }
   });
 
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-jade');
+  grunt.loadNpmTasks('grunt-gh-pages');
   grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-newer');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-watch');
+
 
   grunt.registerTask('default', [
     'clean',
@@ -110,4 +118,7 @@ module.exports = function(grunt) {
     'watch'
   ]);
 
+  grunt.registerTask('deploy', [
+    'gh-pages'
+  ]);
 };

--- a/dist/assets/css/main.css
+++ b/dist/assets/css/main.css
@@ -7,8 +7,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url("/assets/fonts/fontawesome-webfont.eot?v=4.5.0");
-  src: url("/assets/fonts/fontawesome-webfont.eot?#iefix&v=4.5.0") format("embedded-opentype"), url("/assets/fonts/fontawesome-webfont.woff2?v=4.5.0") format("woff2"), url("/assets/fonts/fontawesome-webfont.woff?v=4.5.0") format("woff"), url("/assets/fonts/fontawesome-webfont.ttf?v=4.5.0") format("truetype"), url("/assets/fonts/fontawesome-webfont.svg?v=4.5.0#fontawesomeregular") format("svg");
+  src: url("assets/fonts/fontawesome-webfont.eot?v=4.5.0");
+  src: url("assets/fonts/fontawesome-webfont.eot?#iefix&v=4.5.0") format("embedded-opentype"), url("assets/fonts/fontawesome-webfont.woff2?v=4.5.0") format("woff2"), url("assets/fonts/fontawesome-webfont.woff?v=4.5.0") format("woff"), url("assets/fonts/fontawesome-webfont.ttf?v=4.5.0") format("truetype"), url("assets/fonts/fontawesome-webfont.svg?v=4.5.0#fontawesomeregular") format("svg");
   font-weight: normal;
   font-style: normal; }
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-jade": "^0.15.0",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-gh-pages": "^1.0.0",
     "grunt-sass": "^1.1.0"
   },
   "scripts": {

--- a/src/assets/_scss/vendor/font-awesome/_variables.scss
+++ b/src/assets/_scss/vendor/font-awesome/_variables.scss
@@ -1,7 +1,7 @@
 // Variables
 // --------------------------
 
-$fa-font-path:        "/assets/fonts" !default;
+$fa-font-path:        "assets/fonts" !default;
 $fa-font-size-base:   14px !default;
 $fa-line-height-base: 1 !default;
 //$fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/4.5.0/fonts" !default; // for referencing Bootstrap CDN font files directly


### PR DESCRIPTION
Adds GitHub Pages support and modifies assets path to work in various environments.
- Add GH Pages deploy script
- Modify assets path to use assets/ to support inclusion in subdomain sites
- Modify assets path in FontAwesome
